### PR TITLE
Feature/ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+sudo: false
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=flake8
+
+cache: pip
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ install:
 
 script:
   - tox
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ matrix:
 cache: pip
 
 install:
-  - pip install tox
+  - pip install -U pip setuptools
+  - pip install tox-travis
 
 script:
   - tox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # uroboros
 
+[![Build Status](https://travis-ci.com/pddg/uroboros.svg?branch=master)](https://travis-ci.com/pddg/uroboros)
+
 Simple framework for building scalable CLI tool.
 
 **NOTE**  

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,9 @@ license_file = LICENSE
 classifier =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License 2.0
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skipsdist = True
 envlist = flake8, py35, py36, py37
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,13 @@ commands =
     pipenv install --dev
     pipenv run test
 
+[testenv:py35]
+deps = pipenv
+commands =
+    pip install pathlib2
+    pipenv install --dev
+    pipenv run test
+
 [testenv:flake8]
 basepython = python3.7
 commands =

--- a/uroboros/command.py
+++ b/uroboros/command.py
@@ -68,7 +68,8 @@ class Command(metaclass=abc.ABCMeta):
     def run(self, args: 'argparse.Namespace') -> 'Union[ExitStatus, int]':
         raise NotImplementedError
 
-    def build_option(self, parser: 'argparse.ArgumentParser') -> 'argparse.ArgumentParser':
+    def build_option(self, parser: 'argparse.ArgumentParser') \
+            -> 'argparse.ArgumentParser':
         return parser
 
     def initialize(self, parser: 'Optional[argparse.ArgumentParser]' = None):

--- a/uroboros/option.py
+++ b/uroboros/option.py
@@ -15,7 +15,8 @@ class Option(metaclass=abc.ABCMeta):
         return self.build_option(self.parser)
 
     @abc.abstractmethod
-    def build_option(self, parser: 'argparse.ArgumentParser') -> 'argparse.ArgumentParser':
+    def build_option(self, parser: 'argparse.ArgumentParser') \
+            -> 'argparse.ArgumentParser':
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/uroboros/utils.py
+++ b/uroboros/utils.py
@@ -6,6 +6,8 @@ from uroboros.constants import ExitStatus
 if TYPE_CHECKING:
     from typing import Dict, Union
     from uroboros.command import Command
+    CommandDict = Dict[Command, dict]
+    CommandsDict = Dict[Command, CommandDict]
 
 
 def get_args_command_name(layer: int):
@@ -16,7 +18,7 @@ def get_args_validator_name(layer: int):
     return "__layer{layer}_validator".format(layer=layer)
 
 
-def get_matched_command(name, command_dict: 'Dict[Command, Dict[Command, dict]]') -> 'Dict[Command, dict]':
+def get_matched_command(name, command_dict: 'CommandsDict') -> 'CommandDict':
     for cmd, sub_cmds in command_dict.items():
         if cmd.name == name:
             return {cmd: sub_cmds}
@@ -28,4 +30,5 @@ def to_int(exit_code: 'Union[ExitStatus, int]'):
         return exit_code.value
     if isinstance(exit_code, int):
         return exit_code
-    raise ValueError("exit_code must be 'uroboros.constants.ExitStatus' or int.")
+    raise ValueError(
+        "exit_code must be 'uroboros.constants.ExitStatus' or int.")


### PR DESCRIPTION
Add integration for Travis CI.

Currently, unit test by py.test and lint by flake8 is only supported. In the future, I want to deploy a package to pypi.org when the new release is pushed to master.

**NOTE**
Pipfile.lock missing dependency for `pathlib2` (py.test's dependency) on Python3.5. I ran `pipenv install --dev pytest` on Python 3.7. `pathlib2` is not needed for the environment >= Python 3.6, so it lacks the `pathlib2` dependency. I add it to `testenv:py35` in tox manually.
