### PR TITLE
Improve error message when the command instance has no name

### DIFF
--- a/uroboros/command.py
+++ b/uroboros/command.py
@@ -51,7 +51,8 @@ class Command(metaclass=abc.ABCMeta):
         :return:        Exit status (integer only)
         """
         assert getattr(self, "name", None) is not None, \
-            "{} does not have `name` attribute.".format(self.__class__.__name__)
+            "{} does not have `name` attribute.".format(
+                self.__class__.__name__)
         try:
             self._check_initialized()
         except errors.CommandNotRegisteredError:
@@ -143,7 +144,8 @@ class Command(metaclass=abc.ABCMeta):
             "Given command is not an instance of `uroboros.Command` or" \
             "an instance of its subclass."
         assert getattr(command, "name", None) is not None, \
-            "{} does not have `name` attribute.".format(command.__class__.__name__)
+            "{} does not have `name` attribute.".format(
+                command.__class__.__name__)
         command_id = id(command)
         if command_id in self._parent_ids or \
                 command_id in self._sub_command_ids:

--- a/uroboros/command.py
+++ b/uroboros/command.py
@@ -50,6 +50,8 @@ class Command(metaclass=abc.ABCMeta):
                         `sys.argv` by the parser of this command.
         :return:        Exit status (integer only)
         """
+        assert getattr(self, "name", None) is not None, \
+            "{} does not have `name` attribute.".format(self.__class__.__name__)
         try:
             self._check_initialized()
         except errors.CommandNotRegisteredError:
@@ -140,6 +142,8 @@ class Command(metaclass=abc.ABCMeta):
         assert isinstance(command, Command), \
             "Given command is not an instance of `uroboros.Command` or" \
             "an instance of its subclass."
+        assert getattr(command, "name", None) is not None, \
+            "{} does not have `name` attribute.".format(command.__class__.__name__)
         command_id = id(command)
         if command_id in self._parent_ids or \
                 command_id in self._sub_command_ids:
@@ -288,8 +292,5 @@ class Command(metaclass=abc.ABCMeta):
         return safe_args
 
     def _check_initialized(self):
-        initialized = False
-        if self._parser is not None:
-            initialized = True
-        if not initialized:
+        if self._parser is None:
             raise errors.CommandNotRegisteredError(self.name)


### PR DESCRIPTION
fix #26 

The error message becomes as follows.

```bash
Traceback (most recent call last):
  File "main.py", line 41, in <module>
    root_cmd.add_command(HelloCommand())
  File "/Users/pudding/ghq/github.com/pddg/uroboros/uroboros/command.py", line 146, in add_command
    "{} does not have `name` attribute.".format(command.__class__.__name__)
AssertionError: HelloCommand does not have `name` attribute.
```