### PR TITLE
Fix to use get_options when initialize argument parser

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from uroboros import Option
 from uroboros.errors import CommandDuplicateError
 from .base import RootCommand, SecondCommand, ThirdCommand
 
@@ -318,3 +319,22 @@ class TestCommand(object):
         for cmd in commands:
             key = "after_validate_{}".format(cmd.name)
             assert getattr(args, key, None) == cmd.value
+
+    def test_create_default_parser(self):
+        class Opt(Option):
+            def build_option(self, parser):
+                parser.add_argument("--test", type=str)
+                return parser
+
+        class Cmd(RootCommand):
+            options = [Opt()]
+
+        class Cmd2(RootCommand):
+            def get_options(self):
+                return [Opt()]
+
+        argv = ["--test", "test"]
+        for cmd in [Cmd(), Cmd2()]:
+            cmd_parser = cmd.create_default_parser()
+            args = cmd_parser.parse_args(argv)
+            assert args.test == 'test'

--- a/uroboros/command.py
+++ b/uroboros/command.py
@@ -121,7 +121,7 @@ class Command(metaclass=abc.ABCMeta):
                 name=cmd.name,
                 description=cmd.long_description,
                 help=cmd.short_description,
-                parents=[o.get_parser() for o in cmd.options],
+                parents=[o.get_parser() for o in cmd.get_options()],
             )
             cmd.initialize(sub_parser)
 
@@ -129,7 +129,7 @@ class Command(metaclass=abc.ABCMeta):
         parser = argparse.ArgumentParser(
             prog=self.name,
             description=self.long_description,
-            parents=[o.get_parser() for o in self.options]
+            parents=[o.get_parser() for o in self.get_options()]
         )
         parser.set_defaults(func=self.run)
         return parser


### PR DESCRIPTION
fix #33 

