### PR TITLE
Fix/option duplicate

### DIFF
--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -88,3 +88,14 @@ class TestOption(object):
             pass
         with pytest.raises(TypeError):
             Opt()
+
+    @pytest.mark.parametrize(
+        "option", [
+            NoHookOption(),
+            SampleOption(),
+        ]
+    )
+    def test_call_twice(self, option):
+        expected = option.get_parser()
+        assert option.get_parser() == expected
+

--- a/uroboros/option.py
+++ b/uroboros/option.py
@@ -1,5 +1,6 @@
 import abc
 import argparse
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,6 +12,7 @@ class Option(metaclass=abc.ABCMeta):
     def __init__(self):
         self.parser = argparse.ArgumentParser(add_help=False)
 
+    @lru_cache()
     def get_parser(self) -> 'argparse.ArgumentParser':
         return self.build_option(self.parser)
 


### PR DESCRIPTION
`uroboros.Option` has a `argparse.ArgumentParser` as its instance attribute. So calling `Option.get_parser()` multiple times causes `argparse.ArgumentError` since the options are added multiple times.
`functools.lru_cache` is a cache feature based on given arguments. It caches a instance of `argparse.ArgumentParser` since `get_parser` does not have any arguments except `self`.